### PR TITLE
Fixing GRCPRICE and GRCPRICELASTCHECKED logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -4014,7 +4014,8 @@ def boinc_loop(
             if grc_price:
                 DATABASE["GRCPRICE"] = grc_price
         else:
-            grc_price = DATABASE["GRCPRICE"]
+            grc_price = DATABASE.get("GRCPRICE",0)
+
         # Check profitability of all projects, if none profitable
         # (and user doesn't want unprofitable crunching), sleep for 1hr
         if ONLY_BOINC_IF_PROFITABLE and not dev_loop:


### PR DESCRIPTION
This change moves the update to the GRCPRICELASTCHECKED into the block that will only run if a new price has been pulled.  It also will attempt to pull a new price even if the update period has not been long enough, but no value is present in the DB.