### PR TITLE
Fix: 'NoneType' crash in get_project_mag_ratios_from_response on wallet v5.5.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -3273,6 +3273,9 @@ def get_project_mag_ratios_from_response(
     for project_name, project_racs in projects.items():
         average_rac = sum(project_racs) / len(project_racs)
         project_url = grc_project_name_to_url(project_name, project_resolver_dict)
+        if project_url is None:
+            log.debug("Could not resolve URL for project '{}', skipping mag ratio".format(project_name))
+            continue
         canonical_url = resolve_url_database(project_url)
         return_dict[canonical_url] = mag_per_project / average_rac
     PROJECT_MAG_RATIOS_CACHE = return_dict


### PR DESCRIPTION
Closes #65 

**Environment**
- FindTheMag 3.5 (reports as 3.3 in log — known version string bug)
- Gridcoin wallet v5.5.0.0-5, Windows 1125H2
- Python 3.11.9

**Bug**
FTM crashes with `'NoneType' object has no attribute 'upper'` when fetching mag ratios from the wallet at startup. Falls back to web, crashes there too. BOINC control still runs but all mag ratios are zero.

**Root cause**
`get_project_mag_ratios_from_response()` calls `grc_project_name_to_url()` for each project in `contract_contents.projects`. When that returns `None` (unresolvable project name), it flows unchecked into `resolve_url_database()`, which calls `.upper()` unconditionally on line 155.

**Fix**
Added `None` guard before `resolve_url_database()` call. Unresolvable projects are logged at DEBUG and skipped.

**Tested on**
wallet v5.5.0.0-5 — mag ratios now fetch successfully from wallet at startup.